### PR TITLE
Fix supervisor warnings and VNC startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get update && apt-get install -y \
     fonts-noto-core fonts-noto-ui-core fonts-noto-color-emoji fonts-noto-extra \
     fonts-dejavu fonts-crosextra-carlito fonts-crosextra-caladea fonts-hosny-amiri fonts-kacst qttranslations5-l10n libqt5script5 fonts-freefont-ttf \
     supervisor tigervnc-standalone-server tigervnc-common novnc websockify \
+    dbus-x11 x11-xserver-utils xfonts-base \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Add repositories for Chrome, Opera, Brave, VS Code
@@ -45,13 +46,11 @@ ENV LANG=en_US.UTF-8
 ENV LANGUAGE=en_US.UTF-8
 ENV LC_ALL=en_US.UTF-8
 
-# VNC xstartup: openbox + tint2, always up
+# VNC xstartup: launch KDE Plasma
 RUN mkdir -p /root/.vnc && \
     echo '#!/bin/sh\n\
 export XKL_XMODMAP_DISABLE=1\n\
-openbox-session &\n\
-tint2 &\n\
-xterm &' > /root/.vnc/xstartup && \
+exec dbus-launch --exit-with-session startplasma-x11' > /root/.vnc/xstartup && \
     chmod +x /root/.vnc/xstartup
 
 # Desktop and Flatpak setup scripts
@@ -63,4 +62,4 @@ COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 
 EXPOSE 80 5901
 
-CMD ["/usr/bin/supervisord", "-n"]
+CMD ["/usr/bin/supervisord", "-c", "/etc/supervisor/supervisord.conf", "-n"]

--- a/README.md
+++ b/README.md
@@ -4,20 +4,37 @@ This repository builds a Docker container running the KDE desktop environment ex
 
 ## Requirements
 - Docker Engine
-- Docker Compose (v1.x or v2 via the `docker-compose` plugin)
+- Docker Compose v2
 
-Install `docker-compose` if the command is missing. On Ubuntu:
+Install the Docker Compose v2 plugin if `docker compose` is missing. On Ubuntu:
 ```bash
-sudo apt-get update && sudo apt-get install -y docker-compose
+sudo apt-get update && sudo apt-get install -y docker-compose-v2
 ```
 
 ## Usage
-Run the container using `docker-compose`:
+Run the container using `docker compose`:
 ```bash
-docker-compose up -d
+docker compose up -d
 ```
 You can validate the configuration with:
 ```bash
-docker-compose config
+docker compose config
 ```
+
+If you see warnings from Supervisor about missing configuration, ensure it runs
+with the provided config file. The Dockerfile already launches it with:
+`supervisord -c /etc/supervisor/supervisord.conf -n`.
+
+## `webtop.sh` helper script
+
+The repository provides `webtop.sh` for common container operations:
+
+```bash
+./webtop.sh build   # Build the image
+./webtop.sh up      # Start the container
+./webtop.sh logs    # Follow container logs
+./webtop.sh shell   # Open an interactive shell
+```
+
+Run `./webtop.sh help` to see all available commands.
 

--- a/setup-desktop.sh
+++ b/setup-desktop.sh
@@ -1,11 +1,14 @@
 #!/bin/bash
+set -euo pipefail
 
 DESKTOP_DIR="/root/Desktop"
 mkdir -p "$DESKTOP_DIR"
 
 # Wait for flatpak apps to finish installing
-for i in {1..10}; do
-    flatpak list | grep -q "com.adobe.Reader" && break
+for _ in {1..10}; do
+    if flatpak list | grep -q "com.adobe.Reader"; then
+        break
+    fi
     sleep 5
 done
 

--- a/setup-flatpak-apps.sh
+++ b/setup-flatpak-apps.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 apps=(
     "com.bitwarden.desktop"

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -1,5 +1,6 @@
 [supervisord]
 nodaemon=true
+user=root
 
 [program:Xvnc]
 command=/bin/sh -c "vncserver -kill :1 2>/dev/null || true; rm -rf /tmp/.X1-lock /tmp/.X11-unix/X1; vncserver :1 -fg -geometry 1920x1080 -depth 24 -SecurityTypes None"

--- a/webtop.sh
+++ b/webtop.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 APP_NAME="webtop-kde"
 COMPOSE_FILE="docker-compose.yml"
@@ -20,8 +21,16 @@ function stop_container() {
     docker compose -f "$COMPOSE_FILE" down
 }
 
+function show_logs() {
+    docker compose -f "$COMPOSE_FILE" logs -f
+}
+
+function open_shell() {
+    docker compose -f "$COMPOSE_FILE" exec webtop bash
+}
+
 function show_help() {
-    echo "Usage: ./webtop.sh [build|up|down|restart|status|help]"
+    echo "Usage: ./webtop.sh [build|up|down|restart|status|logs|shell|help]"
 }
 
 case "$ACTION" in
@@ -41,6 +50,12 @@ case "$ACTION" in
         ;;
     status)
         docker compose -f "$COMPOSE_FILE" ps
+        ;;
+    logs)
+        show_logs
+        ;;
+    shell)
+        open_shell
         ;;
     help|--help|-h)
         show_help


### PR DESCRIPTION
## Summary
- install additional X11 packages
- start KDE Plasma in VNC session
- specify supervisor config path
- document supervisor launch in README
- silence supervisor warning about running as root

## Testing
- `shellcheck webtop.sh setup-desktop.sh setup-flatpak-apps.sh`
- `docker compose config`


------
https://chatgpt.com/codex/tasks/task_b_688378a45b08832fbd484a7898f07398