### PR TITLE
Fix browser startup with no-sandbox

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,8 +31,15 @@ RUN mkdir -p /etc/apt/keyrings \
     && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/google-chrome.gpg] http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list \
     && apt-get update \
     && apt-get install -y \
-        google-chrome-stable brave-browser opera-stable code \
+        google-chrome-stable brave-browser opera-stable code chromium-browser \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Allow running Chromium-based browsers as root
+RUN for f in google-chrome.desktop brave-browser.desktop opera.desktop chromium-browser.desktop; do \
+        if [ -f "/usr/share/applications/$f" ]; then \
+            sed -i '/^Exec=/ s@ %U@ --no-sandbox %U@' "/usr/share/applications/$f"; \
+        fi; \
+    done
 
 # Setup Flatpak remote only
 RUN flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo

--- a/setup-desktop.sh
+++ b/setup-desktop.sh
@@ -18,6 +18,7 @@ apps=(
     "firefox.desktop"
     "brave-browser.desktop"
     "opera.desktop"
+    "chromium-browser.desktop"
     "code.desktop"
     "libreoffice-writer.desktop"
     "libreoffice-calc.desktop"
@@ -37,6 +38,11 @@ for app in "${apps[@]}"; do
     if [ -f "/usr/share/applications/$app" ]; then
         cp "/usr/share/applications/$app" "$DESKTOP_DIR/"
         chmod +x "$DESKTOP_DIR/$app"
+        case "$app" in
+            google-chrome.desktop|brave-browser.desktop|opera.desktop|chromium-browser.desktop)
+                sed -i '/^Exec=/ s@ %U@ --no-sandbox %U@' "$DESKTOP_DIR/$app"
+                ;;
+        esac
     fi
 done
 
@@ -48,6 +54,7 @@ flatpak_ids=(
     "com.simplenote.Simplenote"
     "com.blackmagicdesign.resolve"
     "com.github.phase1geo.minder"
+    "org.chromium.Chromium"
 )
 for fapp in "${flatpak_ids[@]}"; do
     for exportdir in /var/lib/flatpak/exports/share/applications /root/.local/share/flatpak/exports/share/applications; do

--- a/setup-flatpak-apps.sh
+++ b/setup-flatpak-apps.sh
@@ -8,6 +8,7 @@ apps=(
     "com.simplenote.Simplenote"
     "com.blackmagicdesign.resolve"
     "com.github.phase1geo.minder"
+    "org.chromium.Chromium"
 )
 
 for app in "${apps[@]}"; do


### PR DESCRIPTION
## Summary
- install Chromium through package manager
- adjust browser desktop entries to add `--no-sandbox`
- install Chromium Flatpak and create launcher

## Testing
- `shellcheck setup-desktop.sh setup-flatpak-apps.sh webtop.sh`

------
https://chatgpt.com/codex/tasks/task_b_6883874d06a4832fb7a4fc56d540dc7f