### PR TITLE
Improve electron app startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ RUN mkdir -p /etc/apt/keyrings \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Allow running Chromium-based browsers as root
-RUN for f in google-chrome.desktop brave-browser.desktop opera.desktop chromium-browser.desktop; do \
+RUN for f in google-chrome.desktop brave-browser.desktop opera.desktop chromium-browser.desktop code.desktop; do \
         if [ -f "/usr/share/applications/$f" ]; then \
             sed -i '/^Exec=/ s@ %U@ --no-sandbox %U@' "/usr/share/applications/$f"; \
         fi; \

--- a/README.md
+++ b/README.md
@@ -38,3 +38,10 @@ The repository provides `webtop.sh` for common container operations:
 
 Run `./webtop.sh help` to see all available commands.
 
+### Root sandbox restrictions
+
+The container runs applications as the `root` user. Electron-based apps like Chrome,
+Chromium, Opera, Brave, VS Code and Bitwarden need the `--no-sandbox` flag when
+executed as root. The setup scripts automatically patch their desktop entries so
+they launch correctly inside the container.
+

--- a/setup-desktop.sh
+++ b/setup-desktop.sh
@@ -39,7 +39,7 @@ for app in "${apps[@]}"; do
         cp "/usr/share/applications/$app" "$DESKTOP_DIR/"
         chmod +x "$DESKTOP_DIR/$app"
         case "$app" in
-            google-chrome.desktop|brave-browser.desktop|opera.desktop|chromium-browser.desktop)
+            google-chrome.desktop|brave-browser.desktop|opera.desktop|chromium-browser.desktop|code.desktop)
                 sed -i '/^Exec=/ s@ %U@ --no-sandbox %U@' "$DESKTOP_DIR/$app"
                 ;;
         esac
@@ -61,7 +61,13 @@ for fapp in "${flatpak_ids[@]}"; do
         desktop_path=$(find "$exportdir" -maxdepth 1 -name "$fapp*.desktop" 2>/dev/null | head -n1)
         if [ -n "$desktop_path" ]; then
             cp "$desktop_path" "$DESKTOP_DIR/"
-            chmod +x "$DESKTOP_DIR/$(basename "$desktop_path")"
+            desktop_file="$DESKTOP_DIR/$(basename "$desktop_path")"
+            chmod +x "$desktop_file"
+            case "$(basename "$desktop_path")" in
+                com.bitwarden.desktop|org.chromium.Chromium*.desktop)
+                    sed -i '/^Exec=/ s@ run @ run --no-sandbox @' "$desktop_file"
+                    ;;
+            esac
         fi
     done
 done


### PR DESCRIPTION
## Summary
- allow `code.desktop` to run without sandbox
- tweak setup script to patch flatpak icons
- document electron sandbox flag for root

## Testing
- `shellcheck setup-desktop.sh`

------
https://chatgpt.com/codex/tasks/task_b_68838e1a2350832fa56142beaff270ee