### PR TITLE
Fix apps with flatpak install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && apt-get install -y \
     ca-certificates lsb-release htop net-tools unzip locales \
     kde-plasma-desktop dolphin kate okular konsole \
     openbox tint2 xterm \
-    firefox libreoffice vlc gimp inkscape shutter winff kodi plank \
+    libreoffice vlc gimp inkscape shutter winff kodi plank \
     flatpak gnome-software-plugin-flatpak \
     fonts-noto-core fonts-noto-ui-core fonts-noto-color-emoji fonts-noto-extra \
     fonts-dejavu fonts-crosextra-carlito fonts-crosextra-caladea fonts-hosny-amiri fonts-kacst qttranslations5-l10n libqt5script5 fonts-freefont-ttf \
@@ -31,13 +31,13 @@ RUN mkdir -p /etc/apt/keyrings \
     && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/google-chrome.gpg] http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list \
     && apt-get update \
     && apt-get install -y \
-        google-chrome-stable brave-browser opera-stable code chromium-browser \
+        google-chrome-stable brave-browser opera-stable code \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Allow running Chromium-based browsers as root
-RUN for f in google-chrome.desktop brave-browser.desktop opera.desktop chromium-browser.desktop code.desktop; do \
+RUN for f in google-chrome.desktop brave-browser.desktop opera.desktop code.desktop; do \
         if [ -f "/usr/share/applications/$f" ]; then \
-            sed -i '/^Exec=/ s@ %U@ --no-sandbox %U@' "/usr/share/applications/$f"; \
+            sed -i '/^Exec=/ s@ %U@ --no-sandbox %U@; /^Exec=/ s@ %F@ --no-sandbox %F@; /^Exec=/ {/--no-sandbox/! s@$@ --no-sandbox@}' "/usr/share/applications/$f"; \
         fi; \
     done
 

--- a/setup-desktop.sh
+++ b/setup-desktop.sh
@@ -15,10 +15,8 @@ done
 # APT/DEB apps
 apps=(
     "google-chrome.desktop"
-    "firefox.desktop"
     "brave-browser.desktop"
     "opera.desktop"
-    "chromium-browser.desktop"
     "code.desktop"
     "libreoffice-writer.desktop"
     "libreoffice-calc.desktop"
@@ -39,8 +37,8 @@ for app in "${apps[@]}"; do
         cp "/usr/share/applications/$app" "$DESKTOP_DIR/"
         chmod +x "$DESKTOP_DIR/$app"
         case "$app" in
-            google-chrome.desktop|brave-browser.desktop|opera.desktop|chromium-browser.desktop|code.desktop)
-                sed -i '/^Exec=/ s@ %U@ --no-sandbox %U@' "$DESKTOP_DIR/$app"
+            google-chrome.desktop|brave-browser.desktop|opera.desktop|code.desktop)
+                sed -i '/^Exec=/ s@ %U@ --no-sandbox %U@; /^Exec=/ s@ %F@ --no-sandbox %F@; /^Exec=/ {/--no-sandbox/! s@$@ --no-sandbox@}' "$DESKTOP_DIR/$app"
                 ;;
         esac
     fi
@@ -55,6 +53,7 @@ flatpak_ids=(
     "com.blackmagicdesign.resolve"
     "com.github.phase1geo.minder"
     "org.chromium.Chromium"
+    "org.mozilla.firefox"
 )
 for fapp in "${flatpak_ids[@]}"; do
     for exportdir in /var/lib/flatpak/exports/share/applications /root/.local/share/flatpak/exports/share/applications; do

--- a/setup-flatpak-apps.sh
+++ b/setup-flatpak-apps.sh
@@ -9,6 +9,7 @@ apps=(
     "com.blackmagicdesign.resolve"
     "com.github.phase1geo.minder"
     "org.chromium.Chromium"
+    "org.mozilla.firefox"
 )
 
 for app in "${apps[@]}"; do


### PR DESCRIPTION
## Summary
- install firefox and chromium through flatpak instead of transitional snap packages
- update setup scripts to copy the flatpak desktop files
- improve `--no-sandbox` patching for desktop entries

## Testing
- `bash -n setup-desktop.sh`
- `bash -n setup-flatpak-apps.sh`


------
https://chatgpt.com/codex/tasks/task_b_688392c2c8b8832f879c7e16688a8d74