### PR TITLE
Set default root password

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,6 +67,9 @@ RUN chmod +x /usr/local/bin/setup-flatpak-apps.sh /usr/local/bin/setup-desktop.s
 
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 
+# Set a default root password for interactive logins
+RUN echo 'root:root' | chpasswd
+
 EXPOSE 80 5901
 
 CMD ["/usr/bin/supervisord", "-c", "/etc/supervisor/supervisord.conf", "-n"]

--- a/README.md
+++ b/README.md
@@ -45,3 +45,9 @@ Chromium, Opera, Brave, VS Code and Bitwarden need the `--no-sandbox` flag when
 executed as root. The setup scripts automatically patch their desktop entries so
 they launch correctly inside the container.
 
+## Default root password
+
+The Docker image sets the root password to `root` for convenience when
+accessing a shell or VNC session. Change this in the `Dockerfile` if you need a
+different password.
+


### PR DESCRIPTION
## Summary
- set root password to `root`
- document default root password

## Testing
- `bash -n setup-desktop.sh`
- `bash -n setup-flatpak-apps.sh`
- `bash -n webtop.sh`
- `docker compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6883de2af388832fa2eab40df8566a41