### PR TITLE
Fix startup of Electron tools when running as root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,7 +61,7 @@ RUN mkdir -p /etc/apt/keyrings \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Allow running Chromium-based browsers as root
-RUN for f in google-chrome.desktop brave-browser.desktop opera.desktop code.desktop; do \
+RUN for f in google-chrome.desktop brave-browser.desktop opera.desktop code.desktop element-desktop.desktop signal-desktop.desktop wire-desktop.desktop; do \
         if [ -f "/usr/share/applications/$f" ]; then \
             sed -i '/^Exec=/ s@ %U@ --no-sandbox %U@; /^Exec=/ s@ %F@ --no-sandbox %F@; /^Exec=/ {/--no-sandbox/! s@$@ --no-sandbox@}' "/usr/share/applications/$f"; \
         fi; \

--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ Run `./webtop.sh help` to see all available commands.
 ### Root sandbox restrictions
 
 The container runs applications as the `root` user. Electron-based apps like Chrome,
-Chromium, Opera, Brave, VS Code and Bitwarden need the `--no-sandbox` flag when
+Chromium-based browsers, Electron collaboration tools like Element, Signal and Wire,
+and apps such as VS Code and Bitwarden need the `--no-sandbox` flag when
 executed as root. The setup scripts automatically patch their desktop entries so
 they launch correctly inside the container.
 

--- a/setup-desktop.sh
+++ b/setup-desktop.sh
@@ -51,7 +51,7 @@ for app in "${apps[@]}"; do
         cp "/usr/share/applications/$app" "$DESKTOP_DIR/"
         chmod +x "$DESKTOP_DIR/$app"
         case "$app" in
-            google-chrome.desktop|brave-browser.desktop|opera.desktop|code.desktop)
+            google-chrome.desktop|brave-browser.desktop|opera.desktop|code.desktop|element-desktop.desktop|signal-desktop.desktop|wire-desktop.desktop)
                 sed -i '/^Exec=/ s@ %U@ --no-sandbox %U@; /^Exec=/ s@ %F@ --no-sandbox %F@; /^Exec=/ {/--no-sandbox/! s@$@ --no-sandbox@}' "$DESKTOP_DIR/$app"
                 ;;
         esac


### PR DESCRIPTION
## Summary
- apply `--no-sandbox` patch to Electron apps Element, Signal and Wire
- include these apps in README instructions

## Testing
- `bash -n setup-desktop.sh`
- `bash -n setup-flatpak-apps.sh`
- `bash -n webtop.sh`


------
https://chatgpt.com/codex/tasks/task_b_68840a8446a0832fa2517f1f6e395024