### PR TITLE
Add default user and stronger root password

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -94,7 +94,9 @@ RUN chmod +x /usr/local/bin/setup-flatpak-apps.sh /usr/local/bin/setup-desktop.s
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 
 # Set a default root password for interactive logins
-RUN echo 'root:root' | chpasswd
+RUN echo 'root:ComplexP@ssw0rd!' | chpasswd \
+    && useradd -m -s /bin/bash devuser \
+    && echo 'devuser:DevPassw0rd!' | chpasswd
 
 EXPOSE 80 5901
 

--- a/README.md
+++ b/README.md
@@ -48,9 +48,14 @@ they launch correctly inside the container.
 
 ## Default root password
 
-The Docker image sets the root password to `root` for convenience when
-accessing a shell or VNC session. Change this in the `Dockerfile` if you need a
-different password.
+The Docker image sets the root password to `ComplexP@ssw0rd!` for convenience
+when accessing a shell or VNC session. Change this in the `Dockerfile` if you
+need a different password.
+
+## Default user account
+
+A standard user named `devuser` is available with password `DevPassw0rd!`. Use
+this account for regular logins instead of `root`.
 
 ## Pre-installed applications
 


### PR DESCRIPTION
## Summary
- set a stronger root password in the Dockerfile
- create a non-root user `devuser`
- document new credentials in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_688426c4dacc832fbdd50a9de860db67