### PR TITLE
Fix user management

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ is `AdminPassw0rd!`.
 
 A standard user named `devuser` is available with password `DevPassw0rd!`. Use
 this account for regular logins instead of `root`.
+### User management inside KDE
+The container runs `accounts-daemon` via Supervisor so the **Users** panel in System Settings can list and manage accounts.
+
 
 ## Pre-installed applications
 

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -2,6 +2,20 @@
 nodaemon=true
 user=root
 
+[program:dbus]
+command=/usr/bin/dbus-daemon --system --nofork
+priority=5
+autostart=true
+autorestart=true
+user=root
+
+[program:accounts-daemon]
+command=/usr/lib/accountsservice/accounts-daemon
+priority=6
+autostart=true
+autorestart=true
+user=root
+
 [program:Xvnc]
 command=/bin/sh -c "vncserver -kill :1 2>/dev/null || true; rm -rf /tmp/.X1-lock /tmp/.X11-unix/X1; vncserver :1 -fg -geometry 1920x1080 -depth 24 -SecurityTypes None"
 priority=10


### PR DESCRIPTION
## Summary
- run dbus and accountsservice under Supervisor
- document accounts-daemon for KDE user management

## Testing
- `docker compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_688438626a50832f85ec3b3ad5182972