### PR TITLE
Enable polkitd for user management

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ is `AdminPassw0rd!`.
 A standard user named `devuser` is available with password `DevPassw0rd!`. Use
 this account for regular logins instead of `root`.
 ### User management inside KDE
-The container runs `accounts-daemon` via Supervisor so the **Users** panel in System Settings can list and manage accounts.
+Supervisor launches `dbus-daemon`, `accounts-daemon` and `polkitd` so the **Users** panel in System Settings can list and manage accounts.
 
 
 ## Pre-installed applications

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -16,6 +16,13 @@ autostart=true
 autorestart=true
 user=root
 
+[program:polkitd]
+command=/usr/lib/policykit-1/polkitd --no-debug
+priority=7
+autostart=true
+autorestart=true
+user=root
+
 [program:Xvnc]
 command=/bin/sh -c "vncserver -kill :1 2>/dev/null || true; rm -rf /tmp/.X1-lock /tmp/.X11-unix/X1; vncserver :1 -fg -geometry 1920x1080 -depth 24 -SecurityTypes None"
 priority=10


### PR DESCRIPTION
## Summary
- run polkitd under Supervisor so KDE user management works
- mention the new services in the README

## Testing
- `docker compose config` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6884f38ffe1c832fb8f9af68e29bea5d