### PR TITLE
Use non-root UID & GID

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,8 @@ services:
     ports:
       - 32768:80
     environment:
-      - PUID=0
-      - PGID=0
+      - PUID=1000
+      - PGID=1000
       - TZ=Asia/Bahrain
       - TITLE=Ubuntu KDE
       - PASSWORD=123@Marketing@321


### PR DESCRIPTION
## Summary
- fix missing users by assigning `PUID` and `PGID` to 1000
- keep Supervisor configuration for dbus, accounts-daemon and polkitd

## Testing
- `docker-compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68850a6ba2f0832fb733d8a3c8caa13c