### PR TITLE
Enable KDE Users panel via polkit agent

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get update && apt-get install -y \
     dbus-x11 x11-xserver-utils xfonts-base snapd \
     wine playonlinux qemu-system qemu-utils qemu-kvm \
     dosbox gnome-terminal lxterminal terminator accountsservice \
+    polkit-kde-agent-1 \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Add repositories for Chrome, Opera, Brave, VS Code
@@ -91,6 +92,7 @@ ENV LC_ALL=en_US.UTF-8
 RUN mkdir -p /root/.vnc && \
     echo '#!/bin/sh\n\
 export XKL_XMODMAP_DISABLE=1\n\
+polkit-kde-authentication-agent-1 &\n\
 exec dbus-launch --exit-with-session startplasma-x11' > /root/.vnc/xstartup && \
     chmod +x /root/.vnc/xstartup
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ is `AdminPassw0rd!`.
 A standard user named `devuser` is available with password `DevPassw0rd!`. Use
 this account for regular logins instead of `root`.
 ### User management inside KDE
-Supervisor launches `dbus-daemon`, `accounts-daemon` and `polkitd` so the **Users** panel in System Settings can list and manage accounts.
+Supervisor launches `dbus-daemon`, `accounts-daemon` and `polkitd` so the **Users** panel in System Settings can list and manage accounts. The VNC session also starts `polkit-kde-authentication-agent-1` so authentication dialogs appear when adding or modifying accounts.
 
 
 ## Pre-installed applications


### PR DESCRIPTION
## Summary
- install `polkit-kde-agent-1`
- start the authentication agent from `xstartup`
- document the agent in README

## Testing
- `./webtop.sh build` *(fails: docker not found)*

------
https://chatgpt.com/codex/tasks/task_b_68850f68f1b4832f8c22caed6e4f59ba