### PR TITLE
Fix accounts-daemon and polkitd paths

### DIFF
--- a/supervisord.conf
+++ b/supervisord.conf
@@ -10,14 +10,14 @@ autorestart=true
 user=root
 
 [program:accounts-daemon]
-command=/usr/lib/accountsservice/accounts-daemon
+command=/usr/libexec/accounts-daemon
 priority=6
 autostart=true
 autorestart=true
 user=root
 
 [program:polkitd]
-command=/usr/lib/policykit-1/polkitd --no-debug
+command=/usr/lib/polkit-1/polkitd --no-debug
 priority=7
 autostart=true
 autorestart=true


### PR DESCRIPTION
## Summary
- fix wrong paths for `accounts-daemon` and `polkitd` in `supervisord.conf`

## Testing
- `shellcheck setup-desktop.sh`
- `shellcheck setup-flatpak-apps.sh`


------
https://chatgpt.com/codex/tasks/task_b_68851cbdf058832fa4e6a0e66b1f2da5