### PR TITLE
Restore repository to commit a1bac2c

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,6 @@ RUN apt-get update && apt-get install -y \
     dbus-x11 x11-xserver-utils xfonts-base snapd \
     wine playonlinux qemu-system qemu-utils qemu-kvm \
     dosbox gnome-terminal lxterminal terminator accountsservice \
-    policykit-1 \
-    polkit-kde-agent-1 openssh-server ttyd \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Add repositories for Chrome, Opera, Brave, VS Code
@@ -93,8 +91,7 @@ ENV LC_ALL=en_US.UTF-8
 RUN mkdir -p /root/.vnc && \
     echo '#!/bin/sh\n\
 export XKL_XMODMAP_DISABLE=1\n\
-# launch KDE Plasma as devuser\n\
-exec su -l devuser -c "dbus-launch --exit-with-session startplasma-x11"' > /root/.vnc/xstartup && \
+exec dbus-launch --exit-with-session startplasma-x11' > /root/.vnc/xstartup && \
     chmod +x /root/.vnc/xstartup
 
 # Desktop and Flatpak setup scripts
@@ -112,7 +109,6 @@ RUN echo 'root:ComplexP@ssw0rd!' | chpasswd \
     && useradd -m -s /bin/bash devuser \
     && echo 'devuser:DevPassw0rd!' | chpasswd
 
-RUN mkdir -p /var/run/sshd
-EXPOSE 22 80 5901 7681
+EXPOSE 80 5901
 
 CMD ["/usr/bin/supervisord", "-c", "/etc/supervisor/supervisord.conf", "-n"]

--- a/README.md
+++ b/README.md
@@ -62,31 +62,7 @@ is `AdminPassw0rd!`.
 A standard user named `devuser` is available with password `DevPassw0rd!`. Use
 this account for regular logins instead of `root`.
 ### User management inside KDE
-Supervisor launches `dbus-daemon`, `accounts-daemon` and `polkitd` so the **Users** panel in System Settings can list and manage accounts. The VNC session also starts `polkit-kde-authentication-agent-1` so authentication dialogs appear when adding or modifying accounts.
-
-## Remote terminal access
-
-Two methods are available for connecting to a shell inside the container:
-
-### SSH
-
-Port **22** is exposed from the container. In `docker-compose.yml` it is mapped to host port **2222** so you can connect using:
-
-```bash
-ssh -p 2222 root@<host-ip>
-```
-
-Use the predefined passwords or your own credentials.
-
-### Browser terminal
-
-A web terminal powered by `ttyd` runs on port **7681**. Access it at:
-
-```
-http://<host-ip>:7681/
-```
-
-The service launches `bash` and uses the same user accounts as SSH.
+Supervisor launches `dbus-daemon`, `accounts-daemon` and `polkitd` so the **Users** panel in System Settings can list and manage accounts.
 
 
 ## Pre-installed applications

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,6 @@ services:
     shm_size: "2gb"
     ports:
       - 32768:80
-      - 2222:22
-      - 7681:7681
     environment:
       - PUID=1000
       - PGID=1000
@@ -20,6 +18,7 @@ services:
       - DISABLE_ZINK=false
       - NO_GAMEPAD=true
       - PATH=/lsiopy/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - HOME=/root
       - LANGUAGE=en_US.UTF-8
       - LANG=en_US.UTF-8
       - TERM=xterm

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -55,19 +55,3 @@ autostart=true
 autorestart=false
 stopsignal=TERM
 user=root
-
-[program:sshd]
-command=/usr/sbin/sshd -D
-priority=50
-autostart=true
-autorestart=true
-stopsignal=TERM
-user=root
-
-[program:ttyd]
-command=/usr/bin/ttyd -p 7681 bash
-priority=60
-autostart=true
-autorestart=true
-stopsignal=TERM
-user=root


### PR DESCRIPTION
## Summary
- reset repository contents to match commit a1bac2c

## Testing
- `git log -1 --stat`
- `docker-compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68853b9b7b0c832f889ff9bf4243ede3