### PR TITLE
Enable SSH and ttyd web terminal access

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get update && apt-get install -y \
     dbus-x11 x11-xserver-utils xfonts-base snapd \
     wine playonlinux qemu-system qemu-utils qemu-kvm \
     dosbox gnome-terminal lxterminal terminator accountsservice \
+    openssh-server ttyd \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Add repositories for Chrome, Opera, Brave, VS Code
@@ -87,8 +88,10 @@ RUN locale-gen en_US.UTF-8 ar_EG.UTF-8 \
 ENV LANG=en_US.UTF-8
 ENV LANGUAGE=en_US.UTF-8
 ENV LC_ALL=en_US.UTF-8
+ENV TTYD_USER=terminal
+ENV TTYD_PASSWORD=terminal
 # VNC xstartup: launch KDE Plasma
-RUN mkdir -p /root/.vnc && \
+RUN mkdir -p /var/run/sshd /root/.vnc && \
     echo '#!/bin/sh\n\
 export XKL_XMODMAP_DISABLE=1\n\
 exec dbus-launch --exit-with-session startplasma-x11' > /root/.vnc/xstartup && \
@@ -109,6 +112,6 @@ RUN echo 'root:ComplexP@ssw0rd!' | chpasswd \
     && useradd -m -s /bin/bash devuser \
     && echo 'devuser:DevPassw0rd!' | chpasswd
 
-EXPOSE 80 5901
+EXPOSE 22 80 5901 7681
 
 CMD ["/usr/bin/supervisord", "-c", "/etc/supervisor/supervisord.conf", "-n"]

--- a/README.md
+++ b/README.md
@@ -21,6 +21,19 @@ You can validate the configuration with:
 docker compose config
 ```
 
+The container exposes an SSH server on port `22` and a web terminal on port
+`7681`. Map these ports when starting the container. With the included
+`docker-compose.yml` the mappings are:
+
+```yaml
+  - "2222:22"      # SSH
+  - "7681:7681"    # ttyd web terminal
+```
+
+The default credentials for the web terminal are `terminal` / `terminal`. You
+can override them by setting the `TTYD_USER` and `TTYD_PASSWORD` environment
+variables.
+
 If you see warnings from Supervisor about missing configuration, ensure it runs
 with the provided config file. The Dockerfile already launches it with:
 `supervisord -c /etc/supervisor/supervisord.conf -n`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
     shm_size: "2gb"
     ports:
       - 32768:80
+      - 2222:22
+      - 7681:7681
     environment:
       - PUID=1000
       - PGID=1000
@@ -17,6 +19,8 @@ services:
       - NVIDIA_DRIVER_CAPABILITIES=all
       - DISABLE_ZINK=false
       - NO_GAMEPAD=true
+      - TTYD_USER=${TTYD_USER:-terminal}
+      - TTYD_PASSWORD=${TTYD_PASSWORD:-terminal}
       - PATH=/lsiopy/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
       - HOME=/root
       - LANGUAGE=en_US.UTF-8

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -55,3 +55,19 @@ autostart=true
 autorestart=false
 stopsignal=TERM
 user=root
+
+[program:sshd]
+command=/usr/sbin/sshd -D
+priority=50
+autostart=true
+autorestart=true
+stopsignal=TERM
+user=root
+
+[program:ttyd]
+command=/bin/sh -c "/usr/bin/ttyd -p 7681 -c ${TTYD_USER}:${TTYD_PASSWORD} bash"
+priority=60
+autostart=true
+autorestart=true
+stopsignal=TERM
+user=root


### PR DESCRIPTION
## Summary
- install `openssh-server` and `ttyd`
- expose ports for SSH and the web terminal
- launch `sshd` and `ttyd` via supervisord
- map new ports and configure credentials in `docker-compose.yml`
- document SSH and web terminal usage in README

## Testing
- `docker compose config` *(fails: `bash: command not found: docker`)*

------
https://chatgpt.com/codex/tasks/task_b_688544c95638832fbc78d7e7b23a5364