### PR TITLE
Fix accounts-daemon start logic

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -73,7 +73,16 @@ if [ -f /var/lib/AccountsService/users/${DEV_USERNAME} ]; then
         echo 'SystemAccount=false' >> /var/lib/AccountsService/users/${DEV_USERNAME}
     fi
 fi
-service accounts-daemon restart
+
+# Launch accounts-daemon manually when systemd services are unavailable
+if command -v systemctl >/dev/null 2>&1; then
+    systemctl restart accounts-daemon || true
+else
+    if pgrep -x accounts-daemon >/dev/null 2>&1; then
+        killall accounts-daemon || true
+    fi
+    /usr/lib/accountsservice/accounts-daemon &
+fi
 
 exec sudo -E -u "${DEV_USERNAME}" \
     DEV_USERNAME="${DEV_USERNAME}" DEV_UID="${DEV_UID}" \


### PR DESCRIPTION
## Summary
- handle environments without systemd
- start accounts-daemon manually when systemd is missing

## Testing
- `bash -n entrypoint.sh`
- `shellcheck entrypoint.sh`

------
https://chatgpt.com/codex/tasks/task_b_6885e2ed2bdc832f95597791e24004ff