### PR TITLE
Handle non-systemd environments

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -75,7 +75,7 @@ if [ -f /var/lib/AccountsService/users/${DEV_USERNAME} ]; then
 fi
 
 # Launch accounts-daemon manually when systemd services are unavailable
-if command -v systemctl >/dev/null 2>&1; then
+if command -v systemctl >/dev/null 2>&1 && [ "$(ps -p 1 -o comm=)" = systemd ]; then
     systemctl restart accounts-daemon || true
 else
     if pgrep -x accounts-daemon >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- restart accounts-daemon via `systemctl` only when systemd is PID 1

## Testing
- `shellcheck entrypoint.sh setup-desktop.sh setup-flatpak-apps.sh webtop.sh` *(shows informational warnings)*
- `docker compose config` *(fails: `docker` command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6885e77254a4832f9bb98c9f343eb261