### PR TITLE
Fix supervisor services

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update && apt-get install -y \
     supervisor tigervnc-standalone-server tigervnc-common novnc websockify \
     dbus-x11 x11-xserver-utils xfonts-base snapd \
     wine playonlinux qemu-system qemu-utils qemu-kvm \
-    dosbox gnome-terminal lxterminal terminator accountsservice \
+    dosbox gnome-terminal lxterminal terminator accountsservice policykit-1 \
     openssh-server ttyd \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
@@ -110,7 +110,7 @@ RUN echo 'root:ComplexP@ssw0rd!' | chpasswd
 
 
 # Ensure updated accountsservice
-RUN apt-get update && apt-get install -y accountsservice && \
+RUN apt-get update && apt-get install -y accountsservice policykit-1 && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 COPY entrypoint.sh /entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -89,7 +89,9 @@ is `AdminPassw0rd!`.
 A standard user named `devuser` is available with password `DevPassw0rd!`. Use
 this account for regular logins instead of `root`.
 ### User management inside KDE
-Supervisor launches `dbus-daemon`, `accounts-daemon` and `polkitd` so the **Users** panel in System Settings can list and manage accounts.
+The entrypoint script ensures `dbus-daemon` and `accounts-daemon` are running
+when systemd is unavailable. `polkitd` is managed by Supervisor so the **Users**
+panel in System Settings can list and manage accounts.
 
 
 ## Pre-installed applications

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -2,22 +2,8 @@
 nodaemon=true
 user=root
 
-[program:dbus]
-command=/usr/bin/dbus-daemon --system --nofork
-priority=5
-autostart=true
-autorestart=true
-user=root
-
-[program:accounts-daemon]
-command=/usr/lib/accountsservice/accounts-daemon
-priority=6
-autostart=true
-autorestart=true
-user=root
-
 [program:polkitd]
-command=/usr/lib/policykit-1/polkitd --no-debug
+command=/usr/libexec/polkitd --no-debug
 priority=7
 autostart=true
 autorestart=true


### PR DESCRIPTION
## Summary
- install policykit-1 so `polkitd` is available
- update supervisord to use `/usr/libexec/polkitd`
- stop supervising `dbus` and `accounts-daemon`
- clarify README on how these services are started

## Testing
- `apt-get update`
- `apt-get install -y docker.io docker-compose`
- `docker-compose config`

------
https://chatgpt.com/codex/tasks/task_b_6885fb57a02c832fb31b5c26646ed6f1