### PR TITLE
Fix supervisord env vars

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -108,6 +108,8 @@ else
 fi
 
 exec env \
+    ENV_DEV_USERNAME="${DEV_USERNAME}" \
+    ENV_DEV_UID="${DEV_UID}" \
     DEV_USERNAME="${DEV_USERNAME}" DEV_UID="${DEV_UID}" \
     XDG_RUNTIME_DIR="/run/user/${DEV_UID}" \
     /usr/bin/supervisord -c /etc/supervisor/supervisord.conf -n


### PR DESCRIPTION
## Summary
- pass `ENV_DEV_USERNAME` and `ENV_DEV_UID` through entrypoint

## Testing
- `bash -n entrypoint.sh`
- `bash -n setup-desktop.sh`
- `bash -n setup-flatpak-apps.sh`
- `shellcheck entrypoint.sh setup-desktop.sh setup-flatpak-apps.sh`

------
https://chatgpt.com/codex/tasks/task_b_688600d9eca0832faab266cff58cb135