### PR TITLE
Fix supervisord environment and DBus setup

### DIFF
--- a/supervisord.conf
+++ b/supervisord.conf
@@ -3,7 +3,7 @@ nodaemon=true
 user=root
 
 [program:polkitd]
-command=/usr/libexec/polkitd --no-debug
+command=/usr/lib/policykit-1/polkitd --no-debug
 priority=7
 autostart=true
 autorestart=true
@@ -16,7 +16,7 @@ autostart=true
 autorestart=true
 stopsignal=TERM
 user=%(ENV_DEV_USERNAME)s
-environment=DISPLAY=:1,XDG_RUNTIME_DIR=/run/user/%(ENV_DEV_UID)s
+environment=DISPLAY=:1,HOME=/home/%(ENV_DEV_USERNAME)s,USER=%(ENV_DEV_USERNAME)s,XDG_RUNTIME_DIR=/run/user/%(ENV_DEV_UID)s
 
 [program:noVNC]
 command=/usr/bin/websockify --web=/usr/share/novnc/ 80 localhost:5901


### PR DESCRIPTION
## Summary
- update polkitd path in supervisor config
- provide HOME and XDG vars for the VNC server
- wait for system dbus socket before launching services
- export HOME when starting supervisord

## Testing
- `shellcheck entrypoint.sh setup-desktop.sh setup-flatpak-apps.sh webtop.sh`

------
https://chatgpt.com/codex/tasks/task_b_688607c47bfc832fa56075b6ebaf3aaf