### PR TITLE
Improve polkitd startup handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,29 @@ The entrypoint script ensures `dbus-daemon` and `accounts-daemon` are running
 when systemd is unavailable. `polkitd` is managed by Supervisor so the **Users**
 panel in System Settings can list and manage accounts.
 
+## Troubleshooting PolicyKit startup
+
+In some environments the `polkitd` binary lives under `/usr/libexec` instead of
+`/usr/lib`. Earlier versions of the container hard-coded the path in
+`supervisord.conf`, which prevented the daemon from starting when the binary was
+elsewhere. The supervisor configuration now launches `polkitd` via the shell and
+checks both locations. `entrypoint.sh` also includes a fallback that spawns
+`polkitd` manually if no running process is detected.
+
+To confirm it is running inside the container:
+
+```bash
+docker compose exec webtop pgrep -a polkitd
+```
+
+If nothing is printed, start the daemon manually using one of:
+
+```bash
+/usr/lib/policykit-1/polkitd --no-debug &
+# or
+/usr/libexec/policykit-1/polkitd --no-debug &
+```
+
 
 ## Pre-installed applications
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -111,6 +111,20 @@ else
     fi
 fi
 
+# Fallback: ensure polkitd is running if supervisor fails to start it
+if ! pgrep -x polkitd >/dev/null 2>&1; then
+    for path in \
+        /usr/lib/policykit-1/polkitd \
+        /usr/libexec/policykit-1/polkitd \
+        $(command -v polkitd 2>/dev/null); do
+        if [ -x "$path" ]; then
+            echo "Starting fallback polkitd at $path"
+            "$path" --no-debug &
+            break
+        fi
+    done
+fi
+
 exec env \
     ENV_DEV_USERNAME="${DEV_USERNAME}" \
     ENV_DEV_UID="${DEV_UID}" \

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -3,7 +3,7 @@ nodaemon=true
 user=root
 
 [program:polkitd]
-command=/usr/lib/policykit-1/polkitd --no-debug
+command=/bin/sh -c 'if [ -x /usr/lib/policykit-1/polkitd ]; then exec /usr/lib/policykit-1/polkitd --no-debug; else exec /usr/libexec/policykit-1/polkitd --no-debug; fi'
 priority=7
 autostart=true
 autorestart=true


### PR DESCRIPTION
## Summary
- use shell wrapper in supervisor to find `polkitd` in either `/usr/lib` or `/usr/libexec`
- add fallback in `entrypoint.sh` to launch `polkitd` manually when supervisor can't
- document the PolicyKit startup fix and troubleshooting tips

## Testing
- `bash -n entrypoint.sh`
- `shellcheck entrypoint.sh`
- `shellcheck setup-desktop.sh setup-flatpak-apps.sh webtop.sh`


------
https://chatgpt.com/codex/tasks/task_b_688615eea7e8832faf4401ec80578ef0