### PR TITLE
Fix supervisor polkitd and KDE permissions

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -111,18 +111,19 @@ else
     fi
 fi
 
-# Fallback: ensure polkitd is running if supervisor fails to start it
-if ! pgrep -x polkitd >/dev/null 2>&1; then
-    for path in \
-        /usr/lib/policykit-1/polkitd \
-        /usr/libexec/policykit-1/polkitd \
-        $(command -v polkitd 2>/dev/null); do
-        if [ -x "$path" ]; then
-            echo "Starting fallback polkitd at $path"
-            "$path" --no-debug &
-            break
-        fi
-    done
+
+# Fix permissions so KDE apps can write files
+chown -R devuser:devuser /home/devuser
+chown -R adminuser:adminuser /home/adminuser
+
+# Fallback: Start polkitd manually if supervisor fails
+if ! pgrep polkitd >/dev/null; then
+  echo "Starting fallback polkitd..."
+  if [ -x /usr/libexec/policykit-1/polkitd ]; then
+    /usr/libexec/policykit-1/polkitd --no-debug &
+  elif [ -x /usr/lib/policykit-1/polkitd ]; then
+    /usr/lib/policykit-1/polkitd --no-debug &
+  fi
 fi
 
 exec env \

--- a/setup-desktop.sh
+++ b/setup-desktop.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -euo pipefail
+set -euxo pipefail
 
 DESKTOP_DIR="/root/Desktop"
 mkdir -p "$DESKTOP_DIR"

--- a/setup-flatpak-apps.sh
+++ b/setup-flatpak-apps.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -euo pipefail
+set -euxo pipefail
 
 apps=(
     "com.bitwarden.desktop"

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -3,7 +3,7 @@ nodaemon=true
 user=root
 
 [program:polkitd]
-command=/bin/sh -c 'if [ -x /usr/lib/policykit-1/polkitd ]; then exec /usr/lib/policykit-1/polkitd --no-debug; else exec /usr/libexec/policykit-1/polkitd --no-debug; fi'
+command=/bin/sh -c "polkitd --no-debug"
 priority=7
 autostart=true
 autorestart=true


### PR DESCRIPTION
## Summary
- ensure polkitd is located via PATH when started by supervisord
- fix home directory permissions and fallback polkitd start in entrypoint
- show execution trace when running setup scripts

## Testing
- `shellcheck entrypoint.sh setup-desktop.sh setup-flatpak-apps.sh`
- `bash -n entrypoint.sh setup-desktop.sh setup-flatpak-apps.sh`
- `docker compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68861a98b8a8832f8998a1ef2c4c0c15