### PR TITLE
Fix polkitd path and avoid root HOME override

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -130,6 +130,4 @@ exec env \
     ENV_DEV_USERNAME="${DEV_USERNAME}" \
     ENV_DEV_UID="${DEV_UID}" \
     DEV_USERNAME="${DEV_USERNAME}" DEV_UID="${DEV_UID}" \
-    HOME="/home/${DEV_USERNAME}" \
-    XDG_RUNTIME_DIR="/run/user/${DEV_UID}" \
     /usr/bin/supervisord -c /etc/supervisor/supervisord.conf -n

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -3,7 +3,7 @@ nodaemon=true
 user=root
 
 [program:polkitd]
-command=/bin/sh -c "polkitd --no-debug"
+command=/bin/sh -c 'if [ -x /usr/lib/policykit-1/polkitd ]; then exec /usr/lib/policykit-1/polkitd --no-debug; else exec /usr/libexec/policykit-1/polkitd --no-debug; fi'
 priority=7
 autostart=true
 autorestart=true


### PR DESCRIPTION
## Summary
- fix PolicyKit startup when polkitd isn't on PATH
- stop overriding HOME/XDG_RUNTIME_DIR for supervisor processes

## Testing
- `bash -n entrypoint.sh`
- `bash -n setup-desktop.sh`
- `bash -n setup-flatpak-apps.sh`


------
https://chatgpt.com/codex/tasks/task_b_688622299e98832f9a2796e867101ae8