### PR TITLE
Fix polkit startup and make setup scripts resilient

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -123,6 +123,8 @@ if ! pgrep polkitd >/dev/null; then
     /usr/libexec/policykit-1/polkitd --no-debug &
   elif [ -x /usr/lib/policykit-1/polkitd ]; then
     /usr/lib/policykit-1/polkitd --no-debug &
+  elif [ -x /usr/lib/polkit-1/polkitd ]; then
+    /usr/lib/polkit-1/polkitd --no-debug &
   fi
 fi
 

--- a/setup-desktop.sh
+++ b/setup-desktop.sh
@@ -98,7 +98,9 @@ done
 
 # Add plank to autostart
 mkdir -p /root/.config/autostart
-cp /usr/share/applications/plank.desktop /root/.config/autostart/
+if [ -f /usr/share/applications/plank.desktop ]; then
+    cp /usr/share/applications/plank.desktop /root/.config/autostart/
+fi
 
 # Set wallpaper (optional)
 WALLPAPER_URL="https://wallpaperaccess.com/full/3314875.jpg"

--- a/setup-flatpak-apps.sh
+++ b/setup-flatpak-apps.sh
@@ -22,6 +22,6 @@ apps=(
 
 for app in "${apps[@]}"; do
     if ! flatpak info "$app" > /dev/null 2>&1; then
-        flatpak install -y --noninteractive flathub "$app"
+        flatpak install -y --noninteractive flathub "$app" || true
     fi
 done

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -3,7 +3,7 @@ nodaemon=true
 user=root
 
 [program:polkitd]
-command=/bin/sh -c 'if [ -x /usr/lib/policykit-1/polkitd ]; then exec /usr/lib/policykit-1/polkitd --no-debug; else exec /usr/libexec/policykit-1/polkitd --no-debug; fi'
+command=/bin/sh -c 'for p in /usr/lib/policykit-1/polkitd /usr/lib/polkit-1/polkitd /usr/libexec/policykit-1/polkitd; do [ -x "$p" ] && exec "$p" --no-debug; done; exit 1'
 priority=7
 autostart=true
 autorestart=true


### PR DESCRIPTION
## Summary
- search additional paths for polkitd so the daemon starts on Ubuntu
- fall back to `/usr/lib/polkit-1/polkitd` when launching manually
- copy Plank autostart entry only if present
- ignore failures when installing Flatpak apps

## Testing
- `bash -n entrypoint.sh setup-desktop.sh setup-flatpak-apps.sh`


------
https://chatgpt.com/codex/tasks/task_b_68862752d244832f9016ec0e37157d66