### PR TITLE
Add privileged guidance for PolicyKit

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,20 @@ If nothing is printed, start the daemon manually using one of:
 /usr/libexec/policykit-1/polkitd --no-debug &
 ```
 
+If `polkitd` repeatedly fails to start with messages like `Operation not
+permitted`, your container may be running without enough privileges. In that
+case start it in **privileged** mode or disable the default seccomp profile so
+PolicyKit can initialize correctly. When using Docker Compose add:
+
+```yaml
+services:
+  webtop:
+    privileged: true
+```
+
+Alternatively specify `--security-opt seccomp=unconfined` when running the
+container.
+
 
 ## Pre-installed applications
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ services:
     build: .
     container_name: webtop-kde
     restart: unless-stopped
+    privileged: true
     shm_size: "2gb"
     ports:
       - 32768:80


### PR DESCRIPTION
## Summary
- clarify that PolicyKit might need privileged container permissions
- add `privileged: true` to the docker-compose example

## Testing
- `shellcheck -x entrypoint.sh setup-desktop.sh setup-flatpak-apps.sh webtop.sh`

------
https://chatgpt.com/codex/tasks/task_b_68862cf224a0832fb1d40fb727415ecd