### PR TITLE
Use admin user for supervisor

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -39,6 +39,7 @@ fi
 
 echo "${ADMIN_USERNAME}:${ADMIN_PASSWORD}" | chpasswd
 usermod -aG sudo "$ADMIN_USERNAME"
+ADMIN_UID=$(id -u "$ADMIN_USERNAME")
 
 sed -i 's/^%sudo.*/%sudo ALL=(ALL) NOPASSWD:ALL/' /etc/sudoers
 
@@ -133,7 +134,7 @@ if ! pgrep polkitd >/dev/null; then
 fi
 
 exec env \
-    ENV_DEV_USERNAME="${DEV_USERNAME}" \
-    ENV_DEV_UID="${DEV_UID}" \
-    DEV_USERNAME="${DEV_USERNAME}" DEV_UID="${DEV_UID}" \
+    ENV_ADMIN_USERNAME="${ADMIN_USERNAME}" \
+    ENV_ADMIN_UID="${ADMIN_UID}" \
+    ADMIN_USERNAME="${ADMIN_USERNAME}" ADMIN_UID="${ADMIN_UID}" \
     /usr/bin/supervisord -c /etc/supervisor/supervisord.conf -n

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -15,8 +15,8 @@ priority=10
 autostart=true
 autorestart=true
 stopsignal=TERM
-user=%(ENV_DEV_USERNAME)s
-environment=DISPLAY=:1,HOME=/home/%(ENV_DEV_USERNAME)s,USER=%(ENV_DEV_USERNAME)s,XDG_RUNTIME_DIR=/run/user/%(ENV_DEV_UID)s
+user=%(ENV_ADMIN_USERNAME)s
+environment=DISPLAY=:1,HOME=/home/%(ENV_ADMIN_USERNAME)s,USER=%(ENV_ADMIN_USERNAME)s,XDG_RUNTIME_DIR=/run/user/%(ENV_ADMIN_UID)s
 
 [program:noVNC]
 command=/usr/bin/websockify --web=/usr/share/novnc/ 80 localhost:5901


### PR DESCRIPTION
## Summary
- run supervisor with admin user details

## Testing
- `bash -n entrypoint.sh`
- `shellcheck entrypoint.sh supervisord.conf`

------
https://chatgpt.com/codex/tasks/task_b_68863b23d070832f8b5c558b407b9a18