### PR TITLE
Allow devuser to manage system settings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -113,6 +113,9 @@ RUN echo 'root:ComplexP@ssw0rd!' | chpasswd
 RUN apt-get update && apt-get install -y accountsservice policykit-1 && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
+# Allow the default user to perform privileged actions without authentication
+COPY devuser-all.rules /etc/polkit-1/rules.d/99-devuser-all.rules
+
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,9 @@ accounts. Use this account for regular logins instead of `root`.
 The entrypoint script ensures `dbus-daemon` and `accounts-daemon` are running
 when systemd is unavailable. `polkitd` is managed by Supervisor so the **Users**
 panel in System Settings can list and manage accounts.
+An additional PolicyKit rule grants the `devuser` account permission to perform
+privileged actions without authentication, allowing changes through the Users
+panel without entering a password.
 
 ## Troubleshooting PolicyKit startup
 

--- a/devuser-all.rules
+++ b/devuser-all.rules
@@ -1,0 +1,6 @@
+// Allow devuser to perform any action without authentication
+polkit.addRule(function(action, subject) {
+    if (subject.user == "devuser") {
+        return polkit.Result.YES;
+    }
+});


### PR DESCRIPTION
## Summary
- grant `devuser` passwordless PolicyKit access
- document policy change in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68864eace234832f9aec71268ced86d3