### PR TITLE
Fix polkit startup issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update && apt-get install -y \
     dbus-x11 x11-xserver-utils xfonts-base snapd \
     wine playonlinux qemu-system qemu-utils qemu-kvm \
     dosbox gnome-terminal lxterminal terminator accountsservice policykit-1 \
-    openssh-server ttyd \
+    openssh-server ttyd libcap2-bin polkit-kde-agent-1 \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Add repositories for Chrome, Opera, Brave, VS Code
@@ -112,6 +112,10 @@ RUN echo 'root:ComplexP@ssw0rd!' | chpasswd
 # Ensure updated accountsservice
 RUN apt-get update && apt-get install -y accountsservice policykit-1 && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Ensure KDE polkit agent starts correctly
+RUN ln -sf /usr/lib/x86_64-linux-gnu/libexec/polkit-kde-authentication-agent-1 /usr/lib/polkit-kde-authentication-agent-1 && \
+    sed -i 's@^Exec=.*@Exec=/usr/lib/polkit-kde-authentication-agent-1@' /etc/xdg/autostart/polkit-kde-authentication-agent-1.desktop
 
 # Allow the default user to perform privileged actions without authentication
 COPY devuser-all.rules /etc/polkit-1/rules.d/99-devuser-all.rules

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,6 +15,16 @@ if [ -n "$ROOT_PASSWORD" ]; then
     echo "root:${ROOT_PASSWORD}" | chpasswd
 fi
 
+# Ensure polkitd system user and group exist
+getent group polkitd >/dev/null || groupadd -r polkitd
+getent passwd polkitd >/dev/null || useradd -r -g polkitd -s /sbin/nologin polkitd
+
+# Apply required capabilities and permissions for PolicyKit
+if command -v setcap >/dev/null 2>&1; then
+    setcap cap_setgid=pe /usr/lib/polkit-1/polkitd || true
+fi
+chmod 4755 /usr/lib/policykit-1/polkit-agent-helper-1
+
 # Ensure group and user exist
 if ! getent group "$DEV_USERNAME" > /dev/null; then
     groupadd -g "$DEV_GID" "$DEV_USERNAME"


### PR DESCRIPTION
## Summary
- install libcap2-bin and polkit-kde-agent-1
- ensure KDE polkit agent points to /usr/lib path
- create polkitd user at runtime and grant capabilities

## Testing
- `setcap cap_setgid=pe /usr/lib/polkit-1/polkitd`
- `chmod 4755 /usr/lib/policykit-1/polkit-agent-helper-1`
- `/usr/lib/polkit-1/polkitd --no-debug >/tmp/pklog 2>&1 & echo $!` *(fails: Exit 1)*

------
https://chatgpt.com/codex/tasks/task_b_68865947c858832fa312231ba477856c