### PR TITLE
Handle existing group id for dev user

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,12 @@ environment:
 These variables control the usernames, passwords and numeric IDs for the
 non-root accounts created by the entrypoint script.
 
+If the container fails to start with repeated `groupadd: GID '1000' already
+exists` messages, another group on the system is already using that numeric
+identifier. Adjust `DEV_GID` (and optionally `DEV_UID`) in
+`docker-compose.yml` to unused values so the accounts can be created
+successfully.
+
 ## Administrator account
 
 An additional user named `adminuser` has sudo privileges. The default password

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -27,7 +27,12 @@ chmod 4755 /usr/lib/policykit-1/polkit-agent-helper-1
 
 # Ensure group and user exist
 if ! getent group "$DEV_USERNAME" > /dev/null; then
-    groupadd -g "$DEV_GID" "$DEV_USERNAME"
+    if getent group "$DEV_GID" > /dev/null; then
+        # Fallback to auto-assigned GID when the desired one already exists
+        groupadd "$DEV_USERNAME"
+    else
+        groupadd -g "$DEV_GID" "$DEV_USERNAME"
+    fi
 fi
 
 # Ensure the ssl-cert group exists for adding the dev user


### PR DESCRIPTION
## Summary
- allow entrypoint to fall back to a new group id when the desired gid already exists
- document the gid conflict scenario in README

## Testing
- `shellcheck entrypoint.sh`

------
https://chatgpt.com/codex/tasks/task_b_6886659ac040832f941b6ba0e9fc4136