### PR TITLE
Fix UID conflicts when adding devuser

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,10 +80,10 @@ These variables control the usernames, passwords and numeric IDs for the
 non-root accounts created by the entrypoint script.
 
 If the container fails to start with repeated `groupadd: GID '1000' already
-exists` messages, another group on the system is already using that numeric
-identifier. Adjust `DEV_GID` (and optionally `DEV_UID`) in
-`docker-compose.yml` to unused values so the accounts can be created
-successfully.
+exists` or `useradd: UID '1000' is not unique` messages, another group or user
+on the system is already using that numeric identifier. Adjust `DEV_GID` (and
+optionally `DEV_UID`) in `docker-compose.yml` to unused values so the accounts
+can be created successfully.
 
 ## Administrator account
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -41,7 +41,12 @@ if ! getent group ssl-cert > /dev/null; then
 fi
 
 if ! id -u "$DEV_USERNAME" > /dev/null 2>&1; then
-    useradd -m -s /bin/bash -u "$DEV_UID" -g "$DEV_GID" "$DEV_USERNAME"
+    if getent passwd "$DEV_UID" > /dev/null; then
+        # Fallback to auto-assigned UID when the desired one already exists
+        useradd -m -s /bin/bash -g "$DEV_GID" "$DEV_USERNAME"
+    else
+        useradd -m -s /bin/bash -u "$DEV_UID" -g "$DEV_GID" "$DEV_USERNAME"
+    fi
 fi
 
 echo "${DEV_USERNAME}:${DEV_PASSWORD}" | chpasswd


### PR DESCRIPTION
## Summary
- update README with troubleshooting steps for UID conflicts
- fallback to an auto-assigned UID if the desired one is already in use

## Testing
- `shellcheck entrypoint.sh`
- `bash -n entrypoint.sh`


------
https://chatgpt.com/codex/tasks/task_b_688669e49918832f9caeccde1a8a5cee