### PR TITLE
Fix pulse-access group creation

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -50,6 +50,9 @@ if ! id -u "$DEV_USERNAME" > /dev/null 2>&1; then
 fi
 
 echo "${DEV_USERNAME}:${DEV_PASSWORD}" | chpasswd
+if ! getent group pulse-access >/dev/null; then
+    groupadd -r pulse-access
+fi
 usermod -aG sudo,ssl-cert,pulse-access,video "$DEV_USERNAME"
 
 # Admin user


### PR DESCRIPTION
## Summary
- ensure `pulse-access` group exists before adding user

## Testing
- `shellcheck entrypoint.sh`

------
https://chatgpt.com/codex/tasks/task_b_68866d9c447c832fb272786db8de40ed