### PR TITLE
Fix container startup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ Run the container using `docker compose`:
 ```bash
 docker compose up -d
 ```
+The container must run with elevated privileges so PolicyKit and other
+components can start correctly. The provided `docker-compose.yml` already
+includes `privileged: true`. If you run the image manually, add either
+`--privileged` or `--security-opt seccomp=unconfined` to your `docker run`
+command.
 You can validate the configuration with:
 ```bash
 docker compose config
@@ -50,6 +55,10 @@ The repository provides `webtop.sh` for common container operations:
 ```
 
 Run `./webtop.sh help` to see all available commands.
+
+`webtop.sh` checks that `docker-compose.yml` enables privileged mode and warns
+if it does not. Running without privileges can prevent PolicyKit and other
+services from starting correctly.
 
 ### Root sandbox restrictions
 

--- a/webtop.sh
+++ b/webtop.sh
@@ -12,6 +12,11 @@ function build_container() {
 
 function start_container() {
     echo "🚀 Starting $APP_NAME..."
+    if ! grep -q "^\s*privileged:\s*true" "$COMPOSE_FILE"; then
+        echo "⚠️  $COMPOSE_FILE does not enable privileged mode."
+        echo "   PolicyKit and other desktop components may fail to start."
+        echo "   Add 'privileged: true' or run with '--security-opt seccomp=unconfined'."
+    fi
     docker compose -f "$COMPOSE_FILE" up -d
     docker compose -f "$COMPOSE_FILE" ps
 }


### PR DESCRIPTION
## Summary
- clarify in README that the image requires privileged mode or an unconfined seccomp profile to start
- warn when starting the container if docker-compose.yml is not privileged

## Testing
- `shellcheck webtop.sh`
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_68867774ff08832f90b12d1bab9eb888