### PR TITLE
Enable Waydroid support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update && apt-get install -y \
     fonts-noto-core fonts-noto-ui-core fonts-noto-color-emoji fonts-noto-extra \
     fonts-dejavu fonts-crosextra-carlito fonts-crosextra-caladea fonts-hosny-amiri fonts-kacst qttranslations5-l10n libqt5script5 fonts-freefont-ttf \
     supervisor tigervnc-standalone-server tigervnc-common novnc websockify \
-    dbus-x11 x11-xserver-utils xfonts-base snapd \
+    dbus-x11 x11-xserver-utils xfonts-base snapd kmod \
     wine playonlinux qemu-system qemu-utils qemu-kvm \
     dosbox gnome-terminal lxterminal terminator accountsservice policykit-1 \
     openssh-server ttyd libcap2-bin polkit-kde-agent-1 \

--- a/README.md
+++ b/README.md
@@ -158,6 +158,34 @@ cannot access required system resources when the container runs with a
 restricted security profile. Launching the container in **privileged** mode or
 with `--security-opt seccomp=unconfined` usually resolves the issue.
 
+### Running Waydroid inside the container
+
+Waydroid relies on the `binder` and `ashmem` kernel modules. Load them on the
+host before starting the container:
+
+```bash
+sudo modprobe binder_linux
+sudo modprobe ashmem_linux   # optional on newer kernels
+```
+
+Start the container in privileged mode and pass the binder filesystem from the
+host:
+
+```bash
+docker run -d --name webtop-kde \
+  --privileged \
+  -v /dev/binderfs:/dev/binderfs \
+  -p 32768:80 -p 2222:22 -p 7681:7681 \
+  webtop-kde:latest
+```
+
+Inside the container initialize Waydroid once:
+
+```bash
+waydroid init
+waydroid session start
+```
+
 
 ## Pre-installed applications
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -139,6 +139,16 @@ fi
 chown -R devuser:devuser /home/devuser
 chown -R adminuser:adminuser /home/adminuser
 
+# Ensure binder/ashmem are available for Waydroid
+if command -v modprobe >/dev/null 2>&1; then
+    modprobe binder_linux || true
+    modprobe ashmem_linux || true
+fi
+mkdir -p /dev/binderfs
+if ! mountpoint -q /dev/binderfs; then
+    mount -t binder binder /dev/binderfs 2>/dev/null || true
+fi
+
 # Fallback: Start polkitd manually if supervisor fails
 if ! pgrep polkitd >/dev/null; then
   echo "Starting fallback polkitd..."


### PR DESCRIPTION
## Summary
- add `kmod` to install list so `modprobe` is available
- mount binderfs and load binder/ashmem modules in entrypoint
- document how to run Waydroid in README

## Testing
- `bash -n entrypoint.sh`


------
https://chatgpt.com/codex/tasks/task_b_688692780b7c832fa5a57741a73885bd