### PR TITLE
Fix Signal repository in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,7 @@ RUN wget -O /usr/share/keyrings/element-io-archive-keyring.gpg https://packages.
 
 # Install signal-desktop
 RUN wget -O- https://updates.signal.org/desktop/apt/keys.asc | gpg --dearmor > /usr/share/keyrings/signal-desktop-keyring.gpg \
-    && echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/signal-desktop-keyring.gpg] https://updates.signal.org/desktop/apt stable main' > /etc/apt/sources.list.d/signal-stable.list \
+    && echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/signal-desktop-keyring.gpg] https://updates.signal.org/desktop/apt xenial main' > /etc/apt/sources.list.d/signal-xenial.list \
     && apt-get update && apt-get install -y signal-desktop && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Install browsers and editors


### PR DESCRIPTION
## Summary
- correct apt source for Signal Desktop

## Testing
- `shellcheck -x entrypoint.sh setup-desktop.sh setup-flatpak-apps.sh webtop.sh`
- `docker compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6886a9072270832f9c6b8e7019e31f19