### PR TITLE
I am fixing a Docker build failure by removing unavailable Flatpak pa…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -98,9 +98,8 @@ RUN apt-get update && apt-get install -y winetricks \
     && wine /tmp/GoogleAdsEditorSetup.exe /silent || true \
     && rm -f /tmp/GoogleAdsEditorSetup.exe
 
-# Setup Flathub remote and install SEMrush and HubSpot via Flatpak
-RUN flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo \
-    && flatpak install -y flathub com.semrush.SEMrush com.hubspot.HubSpot
+# Setup Flathub remote
+RUN flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
 
 # Install WordPress and other web development tools
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
…ckages.

The Flatpak applications com.semrush.SEMrush and com.hubspot.HubSpot are no longer available in the Flathub remote, which was causing the Docker build to fail. I am removing the installation of these two packages to allow the build to succeed.