### PR TITLE
Enable audio support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update && apt-get install -y \
     dbus-x11 x11-xserver-utils xfonts-base snapd kmod \
     wine playonlinux qemu-system qemu-utils qemu-kvm \
     dosbox gnome-terminal lxterminal terminator accountsservice policykit-1 \
-    openssh-server ttyd libcap2-bin polkit-kde-agent-1 \
+    openssh-server ttyd libcap2-bin polkit-kde-agent-1 pulseaudio pavucontrol \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Add repositories for Chrome, Opera, Brave, VS Code

--- a/README.md
+++ b/README.md
@@ -186,6 +186,13 @@ waydroid init
 waydroid session start
 ```
 
+## Audio support
+
+The container runs a PulseAudio server so graphical applications can output sound.
+Ensure the host's sound device is passed through by mapping `/dev/snd` when
+running the container. The included `docker-compose.yml` already exposes this
+device.
+
 
 ## Pre-installed applications
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,3 +43,5 @@ services:
       - LSIO_FIRST_PARTY=true
     volumes:
       - /mnt/docker/mohamed-web/webtop_config:/config
+    devices:
+      - /dev/snd:/dev/snd

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -2,6 +2,14 @@
 nodaemon=true
 user=root
 
+[program:pulseaudio]
+command=/usr/bin/pulseaudio --daemonize=no --system --disallow-exit --exit-idle-time=-1
+priority=5
+autostart=true
+autorestart=true
+user=%(ENV_DEV_USERNAME)s
+environment=HOME=/home/%(ENV_DEV_USERNAME)s,USER=%(ENV_DEV_USERNAME)s,XDG_RUNTIME_DIR=/run/user/%(ENV_DEV_UID)s
+
 [program:polkitd]
 command=/bin/sh -c 'for p in /usr/lib/policykit-1/polkitd /usr/lib/polkit-1/polkitd /usr/libexec/policykit-1/polkitd; do [ -x "$p" ] && exec "$p" --no-debug; done; exit 1'
 priority=7


### PR DESCRIPTION
## Summary
- install PulseAudio and GUI controls
- start PulseAudio using supervisord
- expose the sound device in docker-compose
- document the new audio support

## Testing
- `git show --stat`

------
https://chatgpt.com/codex/tasks/task_b_6887487078e8832fb627ebab141bfb88