### PR TITLE
Fix KDE session startup script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -117,9 +117,12 @@ ENV TTYD_USER=terminal
 ENV TTYD_PASSWORD=terminal
 # VNC xstartup: launch KDE Plasma
 RUN mkdir -p /var/run/sshd /root/.vnc && \
-    echo '#!/bin/sh\n\
-export XKL_XMODMAP_DISABLE=1\n\
-exec dbus-launch --exit-with-session startplasma-x11' > /root/.vnc/xstartup && \
+    cat <<'EOF' >/root/.vnc/xstartup && \
+#!/bin/sh
+export XKL_XMODMAP_DISABLE=1
+export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+exec dbus-launch --exit-with-session /usr/bin/startplasma-x11
+EOF
     chmod +x /root/.vnc/xstartup
 
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -75,7 +75,8 @@ mkdir -p "/home/${DEV_USERNAME}/.vnc"
 cat <<'XEOF' > "/home/${DEV_USERNAME}/.vnc/xstartup"
 #!/bin/sh
 export XKL_XMODMAP_DISABLE=1
-exec dbus-launch --exit-with-session startplasma-x11
+export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+exec dbus-launch --exit-with-session /usr/bin/startplasma-x11
 XEOF
 chown -R "${DEV_USERNAME}":"${DEV_USERNAME}" "/home/${DEV_USERNAME}/.vnc"
 chmod +x "/home/${DEV_USERNAME}/.vnc/xstartup"


### PR DESCRIPTION
## Summary
- add explicit PATH and startplasma path in root vnc xstartup
- update devuser xstartup accordingly

## Testing
- `bash -n entrypoint.sh`

------
https://chatgpt.com/codex/tasks/task_b_688780ea4364832f99b15506861da411