### PR TITLE
Fix Dockerfile parse error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -123,7 +123,7 @@ export XKL_XMODMAP_DISABLE=1
 export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 exec dbus-launch --exit-with-session /usr/bin/startplasma-x11
 EOF
-    chmod +x /root/.vnc/xstartup
+RUN chmod +x /root/.vnc/xstartup
 
 
 # Desktop and Flatpak setup scripts


### PR DESCRIPTION
## Summary
- fix malformed RUN step that caused Dockerfile parse error

## Testing
- `docker compose version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_688783640a34832f95b31a56ce159811