### PR TITLE
Fix startup failures

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -137,6 +137,9 @@ COPY setup-desktop.sh /usr/local/bin/setup-desktop.sh
 RUN chmod +x /usr/local/bin/setup-flatpak-apps.sh /usr/local/bin/setup-desktop.sh
 
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+# Silence D-Bus warnings about missing 'whoopsie' user
+RUN adduser --system --group --no-create-home whoopsie || true
+
 
 
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -152,8 +152,12 @@ chown -R "${ADMIN_USERNAME}:${ADMIN_USERNAME}" "/home/${ADMIN_USERNAME}"
 
 # Ensure binder/ashmem are available for Waydroid
 if command -v modprobe >/dev/null 2>&1; then
-    modprobe binder_linux || true
-    modprobe ashmem_linux || true
+    if modinfo binder_linux >/dev/null 2>&1; then
+        modprobe binder_linux >/dev/null 2>&1 || true
+    fi
+    if modinfo ashmem_linux >/dev/null 2>&1; then
+        modprobe ashmem_linux >/dev/null 2>&1 || true
+    fi
 fi
 mkdir -p /dev/binderfs
 if ! mountpoint -q /dev/binderfs; then

--- a/setup-desktop.sh
+++ b/setup-desktop.sh
@@ -55,7 +55,11 @@ apps=(
 for app in "${apps[@]}"; do
     desktop_path=""
     for search_dir in /usr/share/applications /var/lib/snapd/desktop/applications; do
-        candidate=$(find "$search_dir" -maxdepth 1 -name "${app}*" -print -quit 2>/dev/null)
+        if [ -d "$search_dir" ]; then
+            candidate=$(find "$search_dir" -maxdepth 1 -name "${app}*" -print -quit 2>/dev/null || true)
+        else
+            candidate=""
+        fi
         if [[ -n "$candidate" ]]; then
             desktop_path="$candidate"
             break
@@ -97,7 +101,11 @@ flatpak_ids=(
 for fapp in "${flatpak_ids[@]}"; do
     for exportdir in /var/lib/flatpak/exports/share/applications \
         /home/${DEV_USERNAME}/.local/share/flatpak/exports/share/applications; do
-        desktop_path=$(find "${exportdir}" -maxdepth 1 -name "${fapp}*.desktop" 2>/dev/null | head -n1)
+        if [ -d "${exportdir}" ]; then
+            desktop_path=$(find "${exportdir}" -maxdepth 1 -name "${fapp}*.desktop" 2>/dev/null | head -n1 || true)
+        else
+            desktop_path=""
+        fi
         if [[ -n "${desktop_path}" ]]; then
             cp "${desktop_path}" "${DESKTOP_DIR}/"
             desktop_file="${DESKTOP_DIR}/$(basename "${desktop_path}")"


### PR DESCRIPTION
## Summary
- create missing `whoopsie` user to silence dbus warning
- avoid failing when desktop entries aren't found
- check for binder/ashmem modules before loading

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_6887e9f874d4832fa0f251c33628eaae