### PR TITLE
I've fixed the Xsession error by using a custom xstartup script.

### DIFF
--- a/supervisord.conf
+++ b/supervisord.conf
@@ -18,7 +18,7 @@ autorestart=true
 user=root
 
 [program:Xvnc]
-command=/bin/sh -c "vncserver -kill :1 2>/dev/null || true; rm -rf /tmp/.X1-lock /tmp/.X11-unix/X1; vncserver :1 -fg -geometry 1920x1080 -depth 24 -SecurityTypes None"
+command=/bin/sh -c "vncserver -kill :1 2>/dev/null || true; rm -rf /tmp/.X1-lock /tmp/.X11-unix/X1; vncserver :1 -fg -geometry 1920x1080 -depth 24 -SecurityTypes None -xstartup /home/%(ENV_DEV_USERNAME)s/.vnc/xstartup"
 priority=10
 autostart=true
 autorestart=true


### PR DESCRIPTION
The Xsession was failing with the error "unable to launch 'true' X session" because vncserver was not using the custom xstartup script that starts the KDE Plasma desktop.

This change fixes the issue by adding the `-xstartup` flag to the vncserver command in `supervisord.conf`, pointing it to the correct script.