### PR TITLE
Disable noVNC and rely on Xpra only

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update && apt-get install -y \
     nextcloud-desktop \
     fonts-noto-core fonts-noto-ui-core fonts-noto-color-emoji fonts-noto-extra \
     fonts-dejavu fonts-crosextra-carlito fonts-crosextra-caladea fonts-hosny-amiri fonts-kacst qttranslations5-l10n libqt5script5 fonts-freefont-ttf \
-    supervisor tigervnc-standalone-server tigervnc-common novnc websockify \
+    supervisor \
     dbus-x11 x11-xserver-utils xfonts-base snapd kmod \
     mesa-utils libgl1-mesa-dri libglx-mesa0 libosmesa6 libglu1-mesa \
     wine playonlinux qemu-system qemu-utils qemu-kvm \
@@ -111,15 +111,6 @@ ENV LANGUAGE=en_US.UTF-8
 ENV LC_ALL=en_US.UTF-8
 ENV TTYD_USER=terminal
 ENV TTYD_PASSWORD=terminal
-# VNC xstartup: launch KDE Plasma
-RUN mkdir -p /var/run/sshd /root/.vnc && \
-    cat <<'EOF' >/root/.vnc/xstartup && \
-#!/bin/sh
-export XKL_XMODMAP_DISABLE=1
-export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-exec dbus-launch --exit-with-session /usr/bin/startplasma-x11
-EOF
-RUN chmod +x /root/.vnc/xstartup
 
 
 # Desktop and Flatpak setup scripts
@@ -147,6 +138,6 @@ RUN chmod +x /entrypoint.sh
 
 ENTRYPOINT ["/entrypoint.sh"]
 
-EXPOSE 22 80 5901 7681 14500
+EXPOSE 22 7681 14500
 
 CMD ["/usr/bin/supervisord", "-c", "/etc/supervisor/supervisord.conf", "-n"]

--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ This project provides a Dockerized, all-in-one, web-accessible Ubuntu KDE deskto
 
 | Service               | URL                                      | Credentials        |
 | --------------------- | ---------------------------------------- | ------------------ |
-| KDE Desktop (noVNC)   | `http://<your-server-ip>:32768`          | -                  |
 | KDE Desktop (Xpra)    | `http://<your-server-ip>:14500`          | -                  |
 | Terminal (ttyd)       | `http://<your-server-ip>:7681`           | `TTYD_USER` / `TTYD_PASSWORD` |
 | SSH                   | `ssh <ADMIN_USERNAME>@<your-server-ip> -p 2222` | `ADMIN_PASSWORD`   |
@@ -46,8 +45,8 @@ This project provides a Dockerized, all-in-one, web-accessible Ubuntu KDE deskto
 - **Credentials**: The values you set in your `.env` file.
 
 ## Usage
+- **Desktop:** Access the full KDE Plasma desktop through your web browser using the Xpra HTML5 client.
 
-- **Desktop:** Access the full KDE Plasma desktop through your web browser using either noVNC or the Xpra HTML5 client.
 - **Applications:** Launch applications from the desktop, application menu, or via the terminal.
 - **Waydroid:** Launch the Waydroid application from the desktop to start the Android container. You can then install and run Android APKs.
 - **Wine:** Windows applications can be installed and run using the provided PlayOnLinux utility or by running the installer directly from the terminal (e.g., `wine setup.exe`).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,6 @@ services:
     privileged: true
     shm_size: "2gb"
     ports:
-      - 32768:80
       - 2222:22
       - 7681:7681
       - 14500:14500

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -75,16 +75,6 @@ usermod -aG sudo "$ADMIN_USERNAME"
 
 sed -i 's/^%sudo.*/%sudo ALL=(ALL) NOPASSWD:ALL/' /etc/sudoers
 
-# Prepare VNC startup script for dev user
-mkdir -p "/home/${DEV_USERNAME}/.vnc"
-cat <<'XEOF' > "/home/${DEV_USERNAME}/.vnc/xstartup"
-#!/bin/sh
-export XKL_XMODMAP_DISABLE=1
-export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-exec dbus-launch --exit-with-session /usr/bin/startplasma-x11
-XEOF
-chown -R "${DEV_USERNAME}":"${DEV_USERNAME}" "/home/${DEV_USERNAME}/.vnc"
-chmod +x "/home/${DEV_USERNAME}/.vnc/xstartup"
 
 # XDG runtime directory
 mkdir -p "/run/user/${DEV_UID}"

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -17,31 +17,15 @@ autostart=true
 autorestart=true
 user=root
 
-[program:Xvnc]
-command=/bin/sh -c "vncserver -kill :1 2>/dev/null || true; rm -rf /tmp/.X1-lock /tmp/.X11-unix/X1; vncserver :1 -fg -geometry 1920x1080 -depth 24 -SecurityTypes None -xstartup /home/%(ENV_DEV_USERNAME)s/.vnc/xstartup"
-priority=10
-autostart=true
-autorestart=true
-stopsignal=TERM
-user=%(ENV_DEV_USERNAME)s
-environment=DISPLAY=:1,HOME=/home/%(ENV_DEV_USERNAME)s,USER=%(ENV_DEV_USERNAME)s,XDG_RUNTIME_DIR=/run/user/%(ENV_DEV_UID)s
-
 [program:xpra]
-command=/usr/bin/xpra shadow :1 --bind-tcp=0.0.0.0:14500 --html=on --daemon=no
+command=/usr/bin/xpra start --bind-tcp=0.0.0.0:14500 --html=on --daemon=no --start=/usr/bin/startplasma-x11
 priority=15
 autostart=true
 autorestart=true
 stopsignal=TERM
 user=%(ENV_DEV_USERNAME)s
-environment=DISPLAY=:1,HOME=/home/%(ENV_DEV_USERNAME)s,USER=%(ENV_DEV_USERNAME)s,XDG_RUNTIME_DIR=/run/user/%(ENV_DEV_UID)s
+environment=HOME=/home/%(ENV_DEV_USERNAME)s,USER=%(ENV_DEV_USERNAME)s,XDG_RUNTIME_DIR=/run/user/%(ENV_DEV_UID)s
 
-[program:noVNC]
-command=/usr/bin/websockify --web=/usr/share/novnc/ 80 localhost:5901
-priority=20
-autostart=true
-autorestart=true
-stopsignal=TERM
-user=root
 
 [program:FlatpakInstaller]
 command=/usr/local/bin/setup-flatpak-apps.sh


### PR DESCRIPTION
## Summary
- drop all Tigervnc setup and packages
- run Xpra as the X11 server
- stop exposing the unused VNC port

## Testing
- `shellcheck entrypoint.sh setup-flatpak-apps.sh setup-desktop.sh webtop.sh`
- `bash -n entrypoint.sh setup-flatpak-apps.sh setup-desktop.sh webtop.sh`


------
https://chatgpt.com/codex/tasks/task_b_688a1e6df38c832fbeee1c97a2816807