### PR TITLE
Fix docker-compose detection in webtop script

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,10 @@ This project provides a Dockerized, all-in-one, web-accessible Ubuntu KDE deskto
 
 3. **Build and Run:**
    ```bash
+   # If you have the Docker Compose plugin
    docker compose up -d
+   # Or if you're using the legacy docker-compose binary
+   docker-compose up -d
    ```
    This will build the Docker image and start the webtop container in the background.
 

--- a/webtop.sh
+++ b/webtop.sh
@@ -5,9 +5,20 @@ APP_NAME="webtop-kde"
 COMPOSE_FILE="docker-compose.yml"
 ACTION=${1:-up}  # Default action is 'up'
 
+# Detect whether the Docker Compose plugin or the standalone docker-compose
+# binary is available. Prefer the plugin when possible for compatibility.
+if docker compose version >/dev/null 2>&1; then
+    DOCKER_COMPOSE=(docker compose)
+elif command -v docker-compose >/dev/null 2>&1; then
+    DOCKER_COMPOSE=(docker-compose)
+else
+    echo "❌ Neither 'docker compose' nor 'docker-compose' is installed." >&2
+    exit 1
+fi
+
 function build_container() {
     echo "🔧 Building $APP_NAME..."
-    docker compose -f "$COMPOSE_FILE" build --no-cache
+    "${DOCKER_COMPOSE[@]}" -f "$COMPOSE_FILE" build --no-cache
 }
 
 function start_container() {
@@ -17,21 +28,21 @@ function start_container() {
         echo "   PolicyKit and other desktop components may fail to start."
         echo "   Add 'privileged: true' or run with '--security-opt seccomp=unconfined'."
     fi
-    docker compose -f "$COMPOSE_FILE" up -d
-    docker compose -f "$COMPOSE_FILE" ps
+    "${DOCKER_COMPOSE[@]}" -f "$COMPOSE_FILE" up -d
+    "${DOCKER_COMPOSE[@]}" -f "$COMPOSE_FILE" ps
 }
 
 function stop_container() {
     echo "🛑 Stopping $APP_NAME..."
-    docker compose -f "$COMPOSE_FILE" down
+    "${DOCKER_COMPOSE[@]}" -f "$COMPOSE_FILE" down
 }
 
 function show_logs() {
-    docker compose -f "$COMPOSE_FILE" logs -f
+    "${DOCKER_COMPOSE[@]}" -f "$COMPOSE_FILE" logs -f
 }
 
 function open_shell() {
-    docker compose -f "$COMPOSE_FILE" exec webtop bash
+    "${DOCKER_COMPOSE[@]}" -f "$COMPOSE_FILE" exec webtop bash
 }
 
 function show_help() {
@@ -54,7 +65,7 @@ case "$ACTION" in
         start_container
         ;;
     status)
-        docker compose -f "$COMPOSE_FILE" ps
+        "${DOCKER_COMPOSE[@]}" -f "$COMPOSE_FILE" ps
         ;;
     logs)
         show_logs


### PR DESCRIPTION
## Summary
- handle both `docker compose` and `docker-compose` in `webtop.sh`
- document the alternative command in the README

## Testing
- `bash -n entrypoint.sh setup-desktop.sh setup-flatpak-apps.sh webtop.sh`


------
https://chatgpt.com/codex/tasks/task_b_688a3301139c832fb9d9595eb140daf2